### PR TITLE
Setting/#3

### DIFF
--- a/src/main/java/com/posomo/saltit/exception/ErrorCode.java
+++ b/src/main/java/com/posomo/saltit/exception/ErrorCode.java
@@ -1,0 +1,24 @@
+package com.posomo.saltit.exception;
+
+import lombok.Getter;
+
+@Getter
+public enum ErrorCode {
+    METHOD_NOT_ALLOWED(405, "C002", " Invalid Input Value"),
+    HANDLE_ACCESS_DENIED(403, "C006", "Access is Denied");
+    private final String code;
+    private final String message;
+    private int status;
+
+    ErrorCode(final int status, final String code, final String message) {
+        this.status = status;
+        this.message = message;
+        this.code = code;
+    }
+    public static ErrorResponse enumToEntity(ErrorCode errorCode){
+        return ErrorResponse.builder().code(errorCode.getCode())
+                .message(errorCode.getMessage())
+                .status(errorCode.getStatus())
+                .build();
+    }
+}

--- a/src/main/java/com/posomo/saltit/exception/ErrorResponse.java
+++ b/src/main/java/com/posomo/saltit/exception/ErrorResponse.java
@@ -1,0 +1,16 @@
+package com.posomo.saltit.exception;
+
+import lombok.Builder;
+
+public class ErrorResponse {
+    private String code;
+    private String message;
+    private int status;
+
+    @Builder
+    public ErrorResponse(String code,String message,int status){
+        this.code=code;
+        this.message=message;
+        this.status=status;
+    }
+}

--- a/src/main/java/com/posomo/saltit/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/posomo/saltit/exception/GlobalExceptionHandler.java
@@ -1,0 +1,29 @@
+package com.posomo.saltit.exception;
+
+import com.posomo.saltit.exception.exceptions.ExampleException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.nio.charset.Charset;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    private HttpHeaders getJsonMediaTypeHttpHeader(){
+        HttpHeaders header = new HttpHeaders();
+        header.setContentType(new MediaType("application", "json", Charset.forName("UTF-8")));
+        return header;
+    }
+
+    @ExceptionHandler(ExampleException.class)
+    public ResponseEntity<ErrorResponse> handleExampleException(ExampleException e){
+        HttpHeaders header = getJsonMediaTypeHttpHeader();
+        ErrorResponse errorResponse = ErrorCode.enumToEntity(ErrorCode.METHOD_NOT_ALLOWED);
+        return new ResponseEntity<>(errorResponse ,header, HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/posomo/saltit/exception/exceptions/ExampleException.java
+++ b/src/main/java/com/posomo/saltit/exception/exceptions/ExampleException.java
@@ -1,0 +1,4 @@
+package com.posomo.saltit.exception.exceptions;
+
+public class ExampleException extends Exception{
+}


### PR DESCRIPTION
## 💡 이슈
resolve #10 

🌵 상세 내용 (예외 처리 핸들링)
에러 코드는 enum 타입으로 한 곳에서 관리합니다.
에러 코드가 전체적으로 흩어져있을 경우 코드, 메시지의 중복을 방지하기 어렵고 전체적으로 관리하는 것이 매우 어렵습니다. 에러 메시지는 Common과 각 도메인별로 관리하는 것이 효율적일 거 같습니다.

REST API 에러 핸들링을 표준화하기위한 노력으로, IETF는 일반화된 에러 핸들링 스키마를 만드는 RFC 7807을 고안했습니다. https://tools.ietf.org/html/rfc7807
이 스키마는 5개의 파트로 이루어져 있습니다.

type - 에러를 분류하기 위한 URI 식별자
title - 사람이 읽을 수 있는 간단한 에러에 대한 메세지
status - HTTP 응답 코드 (optional)
detail - 사람이 읽을 수 있는 에러에 대한 설명
intance - 에러가 발생한 URI
해당 부분을 간소화 해서 저희끼리 정한 오류 코드, 간단한 에러에 대한 메세지, HTTP 응답 코드를 담은 ErrorResponse객체를 만들었습니다.
에러에 관한 정보를 enum 타입으로 한 곳에서 관리하기 때문에 ErrorResponse 객체의 생성 또한 에러 Enum 객체에 의존적이어야 하므로 ErrorResponse객체의 생성 책임을 ErrorCode(Enum)객체에게 위임했습니다.

📖 참고 사항
https://cheese10yun.github.io/spring-guide-exception/
https://pjh3749.tistory.com/273
https://www.baeldung.com/rest-api-error-handling-best-practices