### PR TITLE
Feat: Backend 도커파일 및 Github action 설정 파일 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,76 @@
+name: deploy
+
+on:
+  push:
+    branches: [ "main" ]
+      
+jobs:
+  CI-CD:
+    runs-on: ubuntu-latest
+    steps:
+
+    ## jdk setting
+    - uses: actions/checkout@v3
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin' # https://github.com/actions/setup-java
+    
+    ## gradle caching
+    - name: Gradle Caching
+      uses: actions/cache@v3
+      with:
+        path: |  
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
+          
+    ## create application.yml
+    - name: make application.yml
+      if: contains(github.ref, 'main')
+      run: |
+        mkdir ./src/main/resources
+        cd ./src/main/resources
+        touch ./application.yml
+        echo "${{ secrets.SECRET_YML }}" > ./application.yml
+      shell: bash
+      
+    ## gradle build
+    - name: Build with Gradle
+      run: |
+        chmod +x ./gradlew
+        ./gradlew clean build --exclude-task test
+    
+    ## docker build & push to main
+    - name: Docker build & push
+      if: contains(github.ref, 'main')
+      run: |
+          echo ${{ secrets.DOCKER_TOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+          docker build -t ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }} -f Dockerfile .
+          docker push ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }}
+          
+    ## deploy to main
+    - name: Deploy to main
+      uses: appleboy/ssh-action@master
+      id: deploy-main
+      if: contains(github.ref, 'main')
+      with:
+        host: ${{ secrets.HOST }}
+        username: ${{ secrets.USERNAME }}
+        key: ${{ secrets.REMOTE_SSH_KEY }}
+        port: ${{ secrets.SSH_PORT }}
+        script: |
+            cd /home/ubuntu/saltit-ec2-environment/
+            echo ${{ secrets.DOCKER_TOKEN }} | sudo docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+            chmod +x release-process.sh
+            sudo sh release-process.sh
+            
+            
+      
+      
+      
+      
+      

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:17-alpine
+EXPOSE 8080
+COPY build/libs/saltit-0.0.1-SNAPSHOT.jar app.jar
+ENTRYPOINT ["java","-jar","/app.jar"]


### PR DESCRIPTION
## 💡 이슈
resolve #{}

## 🤩 개요
Backend의 빠른 배포를 위한 CI/CD 파이프라인 구축

## 🧑‍💻 작업 사항
Backend 도커파일 및 Github action 설정 파일 추가

## 📖 참고 사항
- 옮기는데 실수가 없었다면, 이 PR이 닫힌 이후로 배포가 바로바로 http://3.35.147.39/에 적용이 될것으로 예상됨.
- 추가적으로 github-secret을 굉장히 많이 추가하였으므로, 사실 한눈에 알아볼 수 있게 설정을 해두었지만, 혹시 모르니 추후에 설명을 드리도록 하겠습니다.