### PR TITLE
feat: add get Region List API

### DIFF
--- a/src/main/java/com/posomo/saltit/controller/RegionController.java
+++ b/src/main/java/com/posomo/saltit/controller/RegionController.java
@@ -1,0 +1,12 @@
+package com.posomo.saltit.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.posomo.saltit.domain.region.dto.RegionListResponseDto;
+
+@RequestMapping("/api/v1/region")
+public interface RegionController {
+	@GetMapping("/list")
+	RegionListResponseDto getRegionList();
+}

--- a/src/main/java/com/posomo/saltit/controller/RegionControllerV1.java
+++ b/src/main/java/com/posomo/saltit/controller/RegionControllerV1.java
@@ -1,0 +1,22 @@
+package com.posomo.saltit.controller;
+
+import org.springframework.web.bind.annotation.RestController;
+
+import com.posomo.saltit.domain.region.dto.RegionListResponseDto;
+import com.posomo.saltit.service.RegionService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
+@RequiredArgsConstructor
+@RestController
+@Log4j2
+public class RegionControllerV1 implements RegionController, RegionControllerV1Swagger {
+
+	private final RegionService regionService;
+
+	@Override
+	public RegionListResponseDto getRegionList() {
+		return regionService.getRegionList();
+	}
+}

--- a/src/main/java/com/posomo/saltit/controller/RegionControllerV1Swagger.java
+++ b/src/main/java/com/posomo/saltit/controller/RegionControllerV1Swagger.java
@@ -1,0 +1,10 @@
+package com.posomo.saltit.controller;
+
+import com.posomo.saltit.domain.region.dto.RegionListResponseDto;
+
+import io.swagger.v3.oas.annotations.Operation;
+
+public interface RegionControllerV1Swagger {
+	@Operation(summary = "Saltit에서 제공할 인기지역과 한국에 존재하는 모든 지역을 보내줍니다.")
+	RegionListResponseDto getRegionList();
+}

--- a/src/main/java/com/posomo/saltit/domain/region/dto/RegionListResponseDto.java
+++ b/src/main/java/com/posomo/saltit/domain/region/dto/RegionListResponseDto.java
@@ -1,0 +1,24 @@
+package com.posomo.saltit.domain.region.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.posomo.saltit.domain.region.entity.District;
+import com.posomo.saltit.domain.region.entity.Region;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class RegionListResponseDto {
+	List<String> area = new ArrayList<>();
+	List<List<String>> region = new ArrayList<>();
+
+	public static RegionListResponseDto of(List<Region> regionList) {
+		List<String> area = regionList.stream().map(Region::getName).toList();
+		List<List<String>> region = regionList.stream().map(regionEntity -> regionEntity.getDistrictList().stream().map(District::getName).toList()).toList();
+		return new RegionListResponseDto(area, region);
+	}
+}

--- a/src/main/java/com/posomo/saltit/domain/region/entity/District.java
+++ b/src/main/java/com/posomo/saltit/domain/region/entity/District.java
@@ -1,0 +1,29 @@
+package com.posomo.saltit.domain.region.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
+public class District {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Integer id;
+
+	private String name;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "region_id")
+	private Region region;
+}

--- a/src/main/java/com/posomo/saltit/domain/region/entity/Region.java
+++ b/src/main/java/com/posomo/saltit/domain/region/entity/Region.java
@@ -1,0 +1,28 @@
+package com.posomo.saltit.domain.region.entity;
+
+import java.util.List;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
+public class Region {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Integer id;
+
+	private String name;
+
+	@OneToMany(mappedBy = "region")
+	private List<District> districtList;
+}

--- a/src/main/java/com/posomo/saltit/repository/DistrictRepository.java
+++ b/src/main/java/com/posomo/saltit/repository/DistrictRepository.java
@@ -1,0 +1,8 @@
+package com.posomo.saltit.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.posomo.saltit.domain.region.entity.District;
+
+public interface DistrictRepository extends JpaRepository<District, Integer> {
+}

--- a/src/main/java/com/posomo/saltit/repository/RegionRepository.java
+++ b/src/main/java/com/posomo/saltit/repository/RegionRepository.java
@@ -1,0 +1,14 @@
+package com.posomo.saltit.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import com.posomo.saltit.domain.region.entity.Region;
+
+public interface RegionRepository extends JpaRepository<Region, Integer> {
+
+	@Query("select r from Region r left join fetch r.districtList")
+	List<Region> findAllWithDistrictList();
+}

--- a/src/main/java/com/posomo/saltit/service/RegionService.java
+++ b/src/main/java/com/posomo/saltit/service/RegionService.java
@@ -1,0 +1,7 @@
+package com.posomo.saltit.service;
+
+import com.posomo.saltit.domain.region.dto.RegionListResponseDto;
+
+public interface RegionService {
+	RegionListResponseDto getRegionList();
+}

--- a/src/main/java/com/posomo/saltit/service/RegionServiceV1.java
+++ b/src/main/java/com/posomo/saltit/service/RegionServiceV1.java
@@ -1,0 +1,24 @@
+package com.posomo.saltit.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.posomo.saltit.domain.region.dto.RegionListResponseDto;
+import com.posomo.saltit.domain.region.entity.Region;
+import com.posomo.saltit.repository.DistrictRepository;
+import com.posomo.saltit.repository.RegionRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Component
+public class RegionServiceV1 implements RegionService {
+	private final RegionRepository regionRepository;
+
+	@Override
+	public RegionListResponseDto getRegionList() {
+		List<Region> regionList = regionRepository.findAllWithDistrictList();
+		return RegionListResponseDto.of(regionList);
+	}
+}


### PR DESCRIPTION
## 🤩 개요
아래의 화면에서 지역에 대한 정보를 서버에서 API로 제공해 주는 기능이다.
DB에 Region과 Distract 테이블을 두고 데이터를 관리 해서, 필요에 따라 지역에 대한 정보를 서버에 독립적으로 변경할 수 있도록 함. 
이는 인기 지역에 대한 정보를 보여주기 위함으로, 차후에 해당 데이터가 변경되는 것을 배치로 계산하거나 간단하게 DB에 직접 쿼리 하는 것으로 변경하는 것을 목표로 한다.

## 🧑‍💻 작업 사항
getRegion API를 생성

## 📖 참고 사항
<img width="644" alt="image" src="https://github.com/posomo/saltit-server/assets/68802559/eb908e43-7fcf-4a9d-b320-46528b9df550">